### PR TITLE
Add payments relation on wallet

### DIFF
--- a/src/Traits/HasWallet.php
+++ b/src/Traits/HasWallet.php
@@ -227,4 +227,18 @@ trait HasWallet
             ->hasMany(config('wallet.transfer.model', Transfer::class), 'from_id')
         ;
     }
+
+    /**
+     * returns all the receiving transfers to this wallet.
+     *
+     * @return HasMany<Transfer>
+     */
+    public function payments(): HasMany
+    {
+        /** @var Wallet $this */
+        return app(CastServiceInterface::class)
+            ->getWallet($this, false)
+            ->hasMany(config('wallet.transfer.model', Transfer::class), 'to_id')
+        ;
+    }
 }


### PR DESCRIPTION
This adds functionality to query the database for transfers in the other direction, payments. Lookup what transfers happened from another wallet to this one.